### PR TITLE
Add missing snippet for listing single fwpolicy

### DIFF
--- a/fwpolicies.rst
+++ b/fwpolicies.rst
@@ -54,6 +54,26 @@ Detailed listing
         :language: javascript
 
 
+List single policy
+------------------
+.. http:get:: /fwpolicies/(uuid:fwpolicy_uuid)/
+
+Gets detailed information for firewall policy identified by `fwpolicy_uuid`.
+
+:statuscode 200: no error
+
+**Example request**:
+
+.. literalinclude:: dumps/request_fwpolicy_get
+    :language: http
+
+
+**Example response**:
+
+
+.. literalinclude:: dumps/response_fwpolicy_get
+    :language: javascript
+
 Create
 ------
 .. http:post:: /fwpolicies/


### PR DESCRIPTION
This PR adds a missing snippet for listing firewall policy.

The request and response dumps exist already. So I just linked it to the `fwpolicy` page.